### PR TITLE
removing extraneous domReference.append after gameOver fx is called

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -211,7 +211,7 @@ function renderBoard(domReference) {
   } else {
     gameOver();
   }
-  domReference.append(tableJeopardy);
+  // domReference.append(tableJeopardy);
 }
 
 function getCurrentScores() {


### PR DESCRIPTION
this is what was causing the 'undefined' to appear on gameover page